### PR TITLE
Make GitHub handles clickable

### DIFF
--- a/TECHNICAL-STEERING-COMMITTEE.md
+++ b/TECHNICAL-STEERING-COMMITTEE.md
@@ -1,20 +1,28 @@
 # Technical Steering Committee
 
-This document lists the members of the Organization's Technical Steering Committee. Voting members may be added once approved by the Technical Steering Committee as described in the Governance document. By adding your name to this list you are agreeing to abide by all Organization polices, including the organizational charter document, the code of conduct, and the antitrust policy. If you are serving on the Technical Steering Committee because of your affiliation with another organization (designated below), you represent that you have authority to bind that organization to these policies.
+This document lists the members of the Organization's Technical Steering
+Committee. Voting members may be added once approved by the Technical Steering
+Committee as described in the Governance document. By adding your name to this
+list you are agreeing to abide by all Organization polices, including the
+organizational charter document, the code of conduct, and the antitrust policy.
+If you are serving on the Technical Steering Committee because of your
+affiliation with another organization (designated below), you represent that
+you have authority to bind that organization to these policies.
 
 | **NAME** | **GitHub Handle** | **Affiliated Organization** |
 | --- | --- | --- |
-| Daniel Allan (Chair) | @danielballan | Brookhaven National Laboratory (NSLS-II)
-| Thomas Caswell | @tacaswell | Brookhaven National Laboratory (NSLS-II)
-| Tom Cobb | @coretl | Diamond Light Source
-| Callum Forrester | @callumforrester | Diamond Light Source
-| Pete Jemian | @prjemian | Argonne National Laboratory (APS)
-| Ken Lauer | @klauer | SLAC National Accelerator Laboratory (LCLS)
-| Zachary Lentz | @ZLLentz | SLAC National Accelerator Laboratory (LCLS)
-| Dylan MacReynolds | @DylanMcReynolds | Lawrence Berkeley National Laboratory (ALS)
-| Maksim Rakitin | @mrakitin | Brookhaven National Laboratory (NSLS-II)
-| Clinton Roy | @clintonroy | Australian Synchrotron
-| Will Smith | @whs92 | Helmholtz-Zentrum Berlin (BESSY-II)
+| Daniel Allan (Chair) | [@danielballan](https://github.com/danielballan) | Brookhaven National Laboratory (NSLS-II)
+| Thomas Caswell | [@tacaswell](https://github.com/tacaswell) | Brookhaven National Laboratory (NSLS-II)
+| Tom Cobb | [@coretl](https://github.com/coretl) | Diamond Light Source
+| Callum Forrester | [@callumforrester](https://github.com/callumforrester) | Diamond Light Source
+| Pete Jemian | [@prjemian](https://github.com/prjemian) | Argonne National Laboratory (APS)
+| Ken Lauer | [@klauer](https://github.com/klauer) | SLAC National Accelerator Laboratory (LCLS)
+| Zachary Lentz | [@ZLLentz](https://github.com/ZLLentz) | SLAC National Accelerator Laboratory (LCLS)
+| Dylan MacReynolds | [@DylanMcReynolds](https://github.com/DylanMcReynolds) | Lawrence Berkeley National Laboratory (ALS)
+| Max Rakitin | [@mrakitin](https://github.com/mrakitin) | Brookhaven National Laboratory (NSLS-II)
+| Clinton Roy | [@clintonroy](https://github.com/clintonroy) | Australian Synchrotron
+| Will Smith | [@whs92](https://github.com/whs92) | Helmholtz-Zentrum Berlin (BESSY-II)
 
 ---
-Adapted from [GitHub's MVG-0.1-beta](https://github.com/github/MVG). Licensed under the [CC-BY 4.0](https://creativecommons.org/licenses/by-sa/4.0/) License.
+Adapted from [GitHub's MVG-0.1-beta](https://github.com/github/MVG). Licensed
+under the [CC-BY 4.0](https://creativecommons.org/licenses/by-sa/4.0/) License.


### PR DESCRIPTION
We are all "clickable" now!

Also, applied vim's `gq` to the paragraphs above & below (no text changes) to fit into the 80 symbols block.