### PR TITLE
Update Technical Steering Committee. Remove Ken; add Robert.

### DIFF
--- a/TECHNICAL-STEERING-COMMITTEE.md
+++ b/TECHNICAL-STEERING-COMMITTEE.md
@@ -16,12 +16,12 @@ you have authority to bind that organization to these policies.
 | Tom Cobb | [@coretl](https://github.com/coretl) | Diamond Light Source
 | Callum Forrester | [@callumforrester](https://github.com/callumforrester) | Diamond Light Source
 | Pete Jemian | [@prjemian](https://github.com/prjemian) | Argonne National Laboratory (APS)
-| Ken Lauer | [@klauer](https://github.com/klauer) | SLAC National Accelerator Laboratory (LCLS)
 | Zachary Lentz | [@ZLLentz](https://github.com/ZLLentz) | SLAC National Accelerator Laboratory (LCLS)
 | Dylan MacReynolds | [@DylanMcReynolds](https://github.com/DylanMcReynolds) | Lawrence Berkeley National Laboratory (ALS)
 | Max Rakitin | [@mrakitin](https://github.com/mrakitin) | Brookhaven National Laboratory (NSLS-II)
 | Clinton Roy | [@clintonroy](https://github.com/clintonroy) | Australian Synchrotron
 | Will Smith | [@whs92](https://github.com/whs92) | Helmholtz-Zentrum Berlin (BESSY-II)
+| Robert Tang-Kong| [@tangkong](https://github.com/tangkong) | SLAC National Accelerator Laboratory (LCLS)
 
 ---
 Adapted from [GitHub's MVG-0.1-beta](https://github.com/github/MVG). Licensed


### PR DESCRIPTION
Ken has departed LCLS and the Bluesky Project. With gratitude for his foundational efforts to build this project and community, we remove his name from the TSC. (You are welcome back any time, @klauer.)

The TSC voted, via email, to add @tangkong to the TSC. Welcome, Robert! Thanks for agreeing to give your time and attention to the project.