### PR TITLE
Add Darren Hunter to Project Advisory Board

### DIFF
--- a/PROJECT-ADVISORY-BOARD.md
+++ b/PROJECT-ADVISORY-BOARD.md
@@ -9,6 +9,7 @@ This document lists the members of the Organization's Project Advisory Board. Vo
 | Joe Handford | joe.handford@diamond.ac.uk | | Diamond Light Source |
 | Mark Heron | mark.heron@diamond.ac.uk | | Diamond Light Source |
 | Alex Hexemer | ahexemer@lbl.gov | | Lawrence Berkeley National Laboratory (ALS) |
+| Darren Hunter | Darren.Hunter@lightsource.ca | | Canadian Light Source |
 | Paul Martin | martinp@ansto.gov.au | | ANSTO (Australian Synchrotron) |
 | Alec Sandy | asandy@anl.gov | @arsandy | Argonne National Laboratory (APS) |
 | Nicholas Schwarz | nschwarz@anl.gov | @nschwarz-aps | Argonne National Laboratory (APS) |


### PR DESCRIPTION
Add Darren Hunter from CLS to Project Advisory Board. 